### PR TITLE
SBT 10000 - Upgrade MessageDispatch.EventStore to use ES 21.10.8

### DIFF
--- a/src/eventstore/CatchupProgress.cs
+++ b/src/eventstore/CatchupProgress.cs
@@ -16,7 +16,7 @@ namespace CorshamScience.MessageDispatch.EventStore
         /// <param name="startPosition">The catchup process' starting position in the stream.</param>
         /// <param name="streamName">The name of the stream which is being caught up on.</param>
         /// <param name="totalEvents">The total number of events in the stream which is being caught up on.</param>
-        public CatchupProgress(int eventsProcessed, long startPosition, string streamName, long totalEvents)
+        public CatchupProgress(int eventsProcessed, ulong startPosition, string streamName, ulong totalEvents)
         {
             EventsProcessed = eventsProcessed;
             StartPosition = startPosition;
@@ -37,12 +37,12 @@ namespace CorshamScience.MessageDispatch.EventStore
         /// <summary>
         /// Gets the starting position in the stream.
         /// </summary>
-        public long StartPosition { get; }
+        public ulong StartPosition { get; }
 
         /// <summary>
         /// Gets the total number of events in the stream.
         /// </summary>
-        public long TotalEvents { get; }
+        public ulong TotalEvents { get; }
 
         /// <summary>
         /// Gets the percentage  of events in the stream which have been processed.
@@ -61,7 +61,7 @@ namespace CorshamScience.MessageDispatch.EventStore
         public override string ToString()
         {
             return
-                $"[{StreamName}] Stream Pos: {StreamPercentage:0.#}% ({EventsProcessed + StartPosition}/{TotalEvents}), Caught up: {CatchupPercentage:0.#}% ({EventsProcessed}/{TotalEvents - StartPosition})";
+                $"[{StreamName}] Stream Pos: {StreamPercentage:0.#}% ({(ulong)EventsProcessed + StartPosition}/{TotalEvents}), Caught up: {CatchupPercentage:0.#}% ({EventsProcessed}/{TotalEvents - StartPosition})";
         }
     }
 }

--- a/src/eventstore/EventStoreAggregateEventDispatcher.cs
+++ b/src/eventstore/EventStoreAggregateEventDispatcher.cs
@@ -8,7 +8,7 @@ namespace CorshamScience.MessageDispatch.EventStore
     using System.Collections.Generic;
     using System.Text;
     using CorshamScience.MessageDispatch.Core;
-    using global::EventStore.ClientAPI;
+    using global::EventStore.Client;
     using Newtonsoft.Json;
     using Newtonsoft.Json.Linq;
 
@@ -47,7 +47,7 @@ namespace CorshamScience.MessageDispatch.EventStore
 
             try
             {
-                IDictionary<string, JToken> metadata = JObject.Parse(Encoding.UTF8.GetString(rawMessage.Event.Metadata));
+                IDictionary<string, JToken> metadata = JObject.Parse(Encoding.UTF8.GetString(rawMessage.Event.Metadata.Span));
 
                 if (!metadata.ContainsKey("ClrType"))
                 {
@@ -100,7 +100,7 @@ namespace CorshamScience.MessageDispatch.EventStore
 
             try
             {
-                var jsonString = Encoding.UTF8.GetString(rawMessage.Event.Data);
+                var jsonString = Encoding.UTF8.GetString(rawMessage.Event.Data.Span);
                 deserialized = JsonConvert.DeserializeObject(jsonString, messageType, _serializerSettings);
                 return deserialized != null;
             }

--- a/src/eventstore/EventStoreJObjectDispatcher.cs
+++ b/src/eventstore/EventStoreJObjectDispatcher.cs
@@ -7,7 +7,7 @@ namespace CorshamScience.MessageDispatch.EventStore
     using System;
     using System.Text;
     using CorshamScience.MessageDispatch.Core;
-    using global::EventStore.ClientAPI;
+    using global::EventStore.Client;
     using Newtonsoft.Json.Linq;
 
     /// <inheritdoc />
@@ -44,7 +44,7 @@ namespace CorshamScience.MessageDispatch.EventStore
 
             try
             {
-                deserialized = JObject.Parse(Encoding.UTF8.GetString(rawMessage.Event.Data));
+                deserialized = JObject.Parse(Encoding.UTF8.GetString(rawMessage.Event.Data.Span));
                 return true;
             }
             catch (Exception)

--- a/src/eventstore/EventStoreSubscriber.cs
+++ b/src/eventstore/EventStoreSubscriber.cs
@@ -312,7 +312,7 @@ namespace CorshamScience.MessageDispatch.EventStore
                     return;
                 }
 
-                if (resolvedEvent.OriginalEventNumber.ToInt64() > long.MaxValue)
+                if (resolvedEvent.OriginalEventNumber.ToUInt64() > long.MaxValue)
                 {
                     _logger.LogError("Event number is too large to be checkpointed. Event number: {EventNumber}", resolvedEvent.OriginalEventNumber);
                     return;

--- a/src/eventstore/EventStoreSubscriber.cs
+++ b/src/eventstore/EventStoreSubscriber.cs
@@ -123,7 +123,7 @@ namespace CorshamScience.MessageDispatch.EventStore
             ILogger logger,
             ulong liveEventThreshold = 10)
             => new EventStoreSubscriber(eventStoreClient, dispatcher, streamName, logger, liveEventThreshold);
-        
+
         /// <summary>
         /// Creates an eventstore catchup subscription using a checkpoint file.
         /// </summary>
@@ -311,7 +311,7 @@ namespace CorshamScience.MessageDispatch.EventStore
                 {
                     return;
                 }
-                
+
                 if (resolvedEvent.OriginalEventNumber.ToInt64() > long.MaxValue)
                 {
                     _logger.LogError("Event number is too large to be checkpointed. Event number: {EventNumber}", resolvedEvent.OriginalEventNumber);

--- a/src/eventstore/EventStoreSubscriber.cs
+++ b/src/eventstore/EventStoreSubscriber.cs
@@ -410,17 +410,6 @@ namespace CorshamScience.MessageDispatch.EventStore
             RestartSubscription();
         }
 
-        private void LiveProcessingStarted()
-        {
-            lock (_liveProcessingTimer)
-            {
-                _liveProcessingTimer.Stop();
-                _catchingUp = false;
-            }
-
-            _logger.LogInformation("Live event processing started");
-        }
-
         private Task EventAppeared(ResolvedEvent resolvedEvent)
         {
             if (resolvedEvent.Event != null && resolvedEvent.Event.EventType == HeartbeatEventType)

--- a/src/eventstore/EventStoreSubscriber.cs
+++ b/src/eventstore/EventStoreSubscriber.cs
@@ -343,8 +343,12 @@ namespace CorshamScience.MessageDispatch.EventStore
 
         private void KillSubscription()
         {
-            _subscription.Dispose();
-            _subscription = null;
+            if (_subscription != null)
+            {
+                _subscription.Dispose();
+                _subscription = null;
+            }
+
             _isSubscribed = false;
         }
     }

--- a/src/eventstore/EventStoreSubscriber.cs
+++ b/src/eventstore/EventStoreSubscriber.cs
@@ -52,13 +52,13 @@ namespace CorshamScience.MessageDispatch.EventStore
             string checkpointFilePath,
             ulong liveEventThreshold)
         {
-            _checkpoint = new WriteThroughFileCheckpoint(checkpointFilePath, "lastProcessedPosition", false, StreamPosition.Start);
+            _checkpoint = new WriteThroughFileCheckpoint(checkpointFilePath, "lastProcessedPosition", false, -1);
             var initialCheckpointPosition = _checkpoint.Read();
             ulong? startingPosition = null;
 
-            if (initialCheckpointPosition != StreamPosition.Start)
+            if (initialCheckpointPosition != -1)
             {
-                startingPosition = initialCheckpointPosition;
+                startingPosition = (ulong)initialCheckpointPosition;
             }
 
             Init(eventStoreClient, dispatcher, streamName, logger, liveEventThreshold, startingPosition);
@@ -313,7 +313,7 @@ namespace CorshamScience.MessageDispatch.EventStore
                     return;
                 }
 
-                _checkpoint.Write(resolvedEvent.OriginalEventNumber.ToUInt64());
+                _checkpoint.Write(resolvedEvent.OriginalEventNumber.ToInt64());
                 _checkpoint.Flush();
             }
             catch (Exception ex)

--- a/src/eventstore/EventStoreSubscriber.cs
+++ b/src/eventstore/EventStoreSubscriber.cs
@@ -123,8 +123,7 @@ namespace CorshamScience.MessageDispatch.EventStore
             ILogger logger,
             ulong liveEventThreshold = 10)
             => new EventStoreSubscriber(eventStoreClient, dispatcher, streamName, logger, liveEventThreshold);
-
-#pragma warning disable CS0618 // Type or member is obsolete
+        
         /// <summary>
         /// Creates an eventstore catchup subscription using a checkpoint file.
         /// </summary>
@@ -312,7 +311,12 @@ namespace CorshamScience.MessageDispatch.EventStore
                 {
                     return;
                 }
-
+                
+                if (resolvedEvent.OriginalEventNumber.ToInt64() > long.MaxValue)
+                {
+                    _logger.LogError("Event number is too large to be checkpointed. Event number: {EventNumber}", resolvedEvent.OriginalEventNumber);
+                    return;
+                }
                 _checkpoint.Write(resolvedEvent.OriginalEventNumber.ToInt64());
                 _checkpoint.Flush();
             }

--- a/src/eventstore/NoSynchronizationContextScope.cs
+++ b/src/eventstore/NoSynchronizationContextScope.cs
@@ -1,0 +1,28 @@
+﻿namespace CorshamScience.MessageDispatch.EventStore
+{
+    using System;
+    using System.Threading;
+
+    internal static class NoSynchronizationContextScope
+    {
+        public static Disposable Enter()
+        {
+            var context = SynchronizationContext.Current;
+            SynchronizationContext.SetSynchronizationContext(null);
+            return new Disposable(context);
+        }
+
+        public struct Disposable : IDisposable
+        {
+            private readonly SynchronizationContext? synchronizationContext;
+
+            public Disposable(SynchronizationContext? synchronizationContext)
+            {
+                this.synchronizationContext = synchronizationContext;
+            }
+
+            public void Dispose() =>
+                SynchronizationContext.SetSynchronizationContext(synchronizationContext);
+        }
+    }
+}

--- a/src/eventstore/SimpleEventStoreDispatcher.cs
+++ b/src/eventstore/SimpleEventStoreDispatcher.cs
@@ -6,10 +6,9 @@ namespace CorshamScience.MessageDispatch.EventStore
 {
     using System;
     using System.Collections.Generic;
-    using System.ServiceModel.Dispatcher;
     using System.Text;
     using CorshamScience.MessageDispatch.Core;
-    using global::EventStore.ClientAPI;
+    using global::EventStore.Client;
     using Newtonsoft.Json;
 
     /// <inheritdoc />
@@ -52,7 +51,7 @@ namespace CorshamScience.MessageDispatch.EventStore
 
             try
             {
-                var jsonString = Encoding.UTF8.GetString(rawMessage.Event.Data);
+                var jsonString = Encoding.UTF8.GetString(rawMessage.Event.Data.Span);
                 deserialized = JsonConvert.DeserializeObject(jsonString, messageType, _serializerSettings);
                 return deserialized != null;
             }

--- a/src/eventstore/WriteThroughFileCheckpoint.cs
+++ b/src/eventstore/WriteThroughFileCheckpoint.cs
@@ -22,8 +22,8 @@ namespace CorshamScience.MessageDispatch.EventStore
         private readonly MemoryStream _memStream;
         private readonly byte[] _buffer;
 
-        private long _last;
-        private long _lastFlushed;
+        private ulong _last;
+        private ulong _lastFlushed;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="WriteThroughFileCheckpoint"/> class.
@@ -32,7 +32,7 @@ namespace CorshamScience.MessageDispatch.EventStore
         /// <param name="name">The name of the checkpoint to write.</param>
         /// <param name="cached">Indicates if the checkpoint has been cached.</param>
         /// <param name="initValue">The initial value to write.</param>
-        public WriteThroughFileCheckpoint(string filename, string name, bool cached, long initValue = 0)
+        public WriteThroughFileCheckpoint(string filename, string name, bool cached, ulong initValue = 0)
         {
             Name = name;
             _cached = cached;
@@ -71,7 +71,7 @@ namespace CorshamScience.MessageDispatch.EventStore
         /// Writes the checkpoint.
         /// </summary>
         /// <param name="checkpoint">Represents the new checkpoint.</param>
-        public void Write(long checkpoint)
+        public void Write(ulong checkpoint)
         {
             Interlocked.Exchange(ref _last, checkpoint);
         }
@@ -96,15 +96,15 @@ namespace CorshamScience.MessageDispatch.EventStore
         /// Reads the current checkpoint.
         /// </summary>
         /// <returns>The current checkpoint.</returns>
-        public long Read()
+        public ulong Read()
         {
             return _cached ? Interlocked.Read(ref _lastFlushed) : ReadCurrent();
         }
 
-        private long ReadCurrent()
+        private ulong ReadCurrent()
         {
             _stream.Seek(0, SeekOrigin.Begin);
-            return _reader.ReadInt64();
+            return _reader.ReadUInt64();
         }
 
         private static class Filenative

--- a/src/eventstore/WriteThroughFileCheckpoint.cs
+++ b/src/eventstore/WriteThroughFileCheckpoint.cs
@@ -22,8 +22,8 @@ namespace CorshamScience.MessageDispatch.EventStore
         private readonly MemoryStream _memStream;
         private readonly byte[] _buffer;
 
-        private ulong _last;
-        private ulong _lastFlushed;
+        private long _last;
+        private long _lastFlushed;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="WriteThroughFileCheckpoint"/> class.
@@ -32,7 +32,7 @@ namespace CorshamScience.MessageDispatch.EventStore
         /// <param name="name">The name of the checkpoint to write.</param>
         /// <param name="cached">Indicates if the checkpoint has been cached.</param>
         /// <param name="initValue">The initial value to write.</param>
-        public WriteThroughFileCheckpoint(string filename, string name, bool cached, ulong initValue = 0)
+        public WriteThroughFileCheckpoint(string filename, string name, bool cached, long initValue = 0)
         {
             Name = name;
             _cached = cached;
@@ -53,6 +53,7 @@ namespace CorshamScience.MessageDispatch.EventStore
             _stream.SetLength(4096);
             _reader = new BinaryReader(_stream);
             _writer = new BinaryWriter(_memStream);
+
             if (!exists)
             {
                 Write(initValue);
@@ -71,7 +72,7 @@ namespace CorshamScience.MessageDispatch.EventStore
         /// Writes the checkpoint.
         /// </summary>
         /// <param name="checkpoint">Represents the new checkpoint.</param>
-        public void Write(ulong checkpoint)
+        public void Write(long checkpoint)
         {
             Interlocked.Exchange(ref _last, checkpoint);
         }
@@ -88,23 +89,21 @@ namespace CorshamScience.MessageDispatch.EventStore
             _stream.Write(_buffer, 0, _buffer.Length);
 
             Interlocked.Exchange(ref _lastFlushed, last);
-
-            // FlushFileBuffers(_file.SafeMemoryMappedFileHandle.DangerousGetHandle());
         }
 
         /// <summary>
         /// Reads the current checkpoint.
         /// </summary>
         /// <returns>The current checkpoint.</returns>
-        public ulong Read()
+        public long Read()
         {
             return _cached ? Interlocked.Read(ref _lastFlushed) : ReadCurrent();
         }
 
-        private ulong ReadCurrent()
+        private long ReadCurrent()
         {
             _stream.Seek(0, SeekOrigin.Begin);
-            return _reader.ReadUInt64();
+            return _reader.ReadInt64();
         }
 
         private static class Filenative

--- a/src/eventstore/eventstore.csproj
+++ b/src/eventstore/eventstore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>CorshamScience.MessageDispatch.EventStore</AssemblyName>
     <RootNamespace>CorshamScience.MessageDispatch.EventStore</RootNamespace>
     <Authors>Corsham Science</Authors>
@@ -20,11 +20,11 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <DocumentationFile>bin\Debug\netstandard2.0\CorshamScience.MessageDispatch.EventStore.xml</DocumentationFile>
+    <DocumentationFile>bin\Debug\net6.0\CorshamScience.MessageDispatch.EventStore.xml</DocumentationFile>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <DocumentationFile>bin\Release\netstandard2.0\CorshamScience.MessageDispatch.EventStore.xml</DocumentationFile>
+    <DocumentationFile>bin\Release\net6.0\CorshamScience.MessageDispatch.EventStore.xml</DocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors />
   </PropertyGroup>
@@ -34,7 +34,8 @@
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="CorshamScience.MessageDispatch.Core" Version="2.0.0" />
-    <PackageReference Include="EventStore.Client" Version="5.0.5" />
+    <PackageReference Include="EventStore.Client.Grpc.Streams" Version="22.0.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
# What's Changed

- Upgraded eventstore project to net6.0 from standard2.0 (required upgrade to used latest gRPC EventStore)
- Removed `EventStore.Clinet.API` and replaced with `EventStore.Client.Grpc.Streams` version 22.0.0
- Replaced the use of long for ulong as EventStore seem to favour that, any assignment of -1 is now `ulong.MinValue` (could be impact here?)
- No option anymore to provide a queue or page size when subscribing, so removed those parameters
- Updated logic for getting last stream position
- Updated logic for live and catchup subscriptions (as detailed in the docs)
- Handling subscription dropped has changed as there is no `User Initiated` reason anymore. Assumed this becomes `Disposed` (as in client disposed)
- Previously killing a subscription would switch on either `Subscription` or `Catchup Subscription` to either `Close `or `Stop`. Now it looks to be simply `Dispose`
- Doesn't seem to be a `LiveProcessingStarted` event anymore 
