### PR TITLE
Fix Division by Zero bug in CatchupProgress

### DIFF
--- a/src/eventstore/CatchupProgress.cs
+++ b/src/eventstore/CatchupProgress.cs
@@ -59,7 +59,10 @@ namespace CorshamScience.MessageDispatch.EventStore
         /// <summary>
         /// Gets the percentage of events in the stream which have been processed (either by number of events or position in the transaction log).
         /// </summary>
-        public decimal OverallPercentage => (decimal)LastProcessedEventPosition / EndOfStreamPosition * 100;
+        public decimal OverallPercentage =>
+            LastProcessedEventPosition == 0 || EndOfStreamPosition == 0
+                ? 0.0m
+                : (decimal)LastProcessedEventPosition / EndOfStreamPosition * 100;
 
         /// <summary>
         /// Gets the percentage of events in the stream which require catching up on, which have been processed (either by number of events or position in the transaction log).

--- a/src/eventstore/CatchupProgress.cs
+++ b/src/eventstore/CatchupProgress.cs
@@ -65,7 +65,7 @@ namespace CorshamScience.MessageDispatch.EventStore
         /// Gets the percentage of events in the stream which require catching up on, which have been processed (either by number of events or position in the transaction log).
         /// </summary>
         public decimal CatchupPercentage =>
-            LastProcessedEventPosition - StartPosition == 0
+            LastProcessedEventPosition - StartPosition == 0 || EndOfStreamPosition - StartPosition == 0
                 ? 0.0m
                 : ((decimal)LastProcessedEventPosition - StartPosition) / (EndOfStreamPosition - StartPosition) * 100;
 


### PR DESCRIPTION
# Fix Division by Zero bug in CatchupProgress

## What's Changed
- The `CatchupPercentage` computed property in `CatchupProgress` handles if the other side of the division is zero.
- The `OverallPercentage` computed property handles division by zero.