### PR TITLE
Implement handling for disconnects on net framework 4.8

### DIFF
--- a/src/MessageDispatch.KurrentDB/KurrentDbSubscriber.cs
+++ b/src/MessageDispatch.KurrentDB/KurrentDbSubscriber.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.Logging;
 using static KurrentDB.Client.KurrentDBClient;
 using System.Timers;
 using Timer = System.Timers.Timer;
+using System.Runtime.InteropServices;
 
 namespace PharmaxoScientific.MessageDispatch.KurrentDB;
 
@@ -84,9 +85,7 @@ public class KurrentDbSubscriber
     /// </summary>
     private void SetupCallbackTimer()
     {
-        Version version = Environment.Version;
-
-        if (version.Major < 8)
+        if (RuntimeInformation.FrameworkDescription.StartsWith(".NET Framework"))
         {
             //Create the timer and set it for a sixty second interval
             _timer = new Timer();

--- a/src/MessageDispatch.KurrentDB/KurrentDbSubscriber.cs
+++ b/src/MessageDispatch.KurrentDB/KurrentDbSubscriber.cs
@@ -99,9 +99,16 @@ public class KurrentDbSubscriber
         _timer = new Timer();
         _timer.Interval = 60000;
 
+        _timer.Elapsed += CallbackEvent;
+
         _timer.AutoReset = true;
 
         _timer.Enabled = true;
+    }
+
+    private void CallbackEvent(object source, ElapsedEventArgs e)
+    {
+        _kurrentDbClient.ReadStreamAsync(Direction.Backwards, _streamName, StreamPosition.End);
     }
 
     /// <summary>

--- a/src/MessageDispatch.KurrentDB/KurrentDbSubscriber.cs
+++ b/src/MessageDispatch.KurrentDB/KurrentDbSubscriber.cs
@@ -270,6 +270,7 @@ public class KurrentDbSubscriber
 #if NETFRAMEWORK
             catch (Grpc.Core.RpcException ex)
             {
+                immediateRetry = false;
                 _startingPosition = _lastProcessedEventPosition;
                 _logger.LogInformation(ex, "Event Store subscription dropped {0}", SubscriptionDroppedReason.SubscriberError);
 

--- a/src/MessageDispatch.KurrentDB/KurrentDbSubscriber.cs
+++ b/src/MessageDispatch.KurrentDB/KurrentDbSubscriber.cs
@@ -9,11 +9,6 @@ using KurrentDB.Client;
 using Microsoft.Extensions.Logging;
 using static KurrentDB.Client.KurrentDBClient;
 
-#if NETFRAMEWORK
-using System.Timers;
-using Timer = System.Timers.Timer;
-#endif
-
 namespace PharmaxoScientific.MessageDispatch.KurrentDB;
 
 /// <summary>
@@ -42,11 +37,6 @@ public class KurrentDbSubscriber
     private IDispatcher<ResolvedEvent> _dispatcher;
     private ILogger _logger;
     private StreamSubscriptionResult _subscription;
-
-#if NETFRAMEWORK
-    private const uint CallbackTimerInterval = 40000;
-    private Timer _timer;
-#endif
 
     /// <summary>
     /// Gets a value indicating whether the view model is ready or not.
@@ -84,32 +74,6 @@ public class KurrentDbSubscriber
         IDispatcher<ResolvedEvent> dispatcher,
         string streamName,
         ILogger logger) => Init(kurrentDbClient, dispatcher, streamName, logger, liveOnly: true);
-
-#if NETFRAMEWORK
-    /// <summary>
-    /// Creates a callback timer to ping KurrentDB every 60s to stop it from going idle
-    /// </summary>
-    private void MaintainConnectionTimer()
-    {
-        //Create the timer and set it for a sixty second interval
-        _timer = new Timer();
-        _timer.Interval = CallbackTimerInterval;
-
-        _timer.Elapsed += PerformKeepAliveRead;
-
-        _timer.AutoReset = true;
-
-        _timer.Enabled = true;
-    }
-
-    private void PerformKeepAliveRead(object source, ElapsedEventArgs e)
-    {
-        if (IsLive)
-        {
-            var subDummy = _subscription.Distinct();
-        }
-    }
-#endif
 
     /// <summary>
     /// Gets a new catchup progress object.
@@ -243,10 +207,6 @@ public class KurrentDbSubscriber
     public async void Start()
     {
         _cts = new CancellationTokenSource();
-
-#if NETFRAMEWORK
-        MaintainConnectionTimer();
-#endif
 
         while (true)
         {

--- a/src/MessageDispatch.KurrentDB/KurrentDbSubscriber.cs
+++ b/src/MessageDispatch.KurrentDB/KurrentDbSubscriber.cs
@@ -265,7 +265,7 @@ public class KurrentDbSubscriber
             {
                 //Ignore the console writeline, it's for debug purposes only.
                 Console.WriteLine("Fetchez la vache");
-                _logger.LogError(ex, "Event Store subscription dropped {0}", SubscriptionDroppedReason.SubscriberError);
+                _logger.LogInformation(ex, "Event Store subscription dropped {0}", SubscriptionDroppedReason.SubscriberError);
             }
 #endif
             catch (Exception ex)

--- a/src/MessageDispatch.KurrentDB/KurrentDbSubscriber.cs
+++ b/src/MessageDispatch.KurrentDB/KurrentDbSubscriber.cs
@@ -261,7 +261,7 @@ public class KurrentDbSubscriber
                 _logger.LogInformation(ex, "Event Store subscription dropped {0}", SubscriptionDroppedReason.Disposed);
                 break;
             }
-        #if NETFRAMEWORK
+#if NETFRAMEWORK
             catch (Grpc.Core.RpcException ex)
             {
                 _logger.LogInformation(ex, "Event Store subscription dropped {0}", SubscriptionDroppedReason.SubscriberError);
@@ -287,7 +287,7 @@ public class KurrentDbSubscriber
                     winHttpExceptionHandled = false;
                 }
             }
-        #endif
+#endif
             catch (Exception ex)
             {
                 IsLive = false;

--- a/src/MessageDispatch.KurrentDB/KurrentDbSubscriber.cs
+++ b/src/MessageDispatch.KurrentDB/KurrentDbSubscriber.cs
@@ -266,10 +266,12 @@ public class KurrentDbSubscriber
 #if NETFRAMEWORK
             catch (Grpc.Core.RpcException ex)
             {
-                //Ignore the console writeline, it's for debug purposes only.
-                Console.WriteLine("Fetchez la vache");
-                _logger.LogInformation(ex, "Event Store subscription dropped {0}", SubscriptionDroppedReason.SubscriberError);
-                TryCreatingSubscription();
+                var innerWebException = ex.InnerException.InnerException;
+                if (innerWebException.Message.Contains("Error 12002"))
+                {
+                    _logger.LogInformation(ex, "Event Store subscription dropped {0}", SubscriptionDroppedReason.SubscriberError);
+                    TryCreatingSubscription();
+                }
             }
 #endif
             catch (Exception ex)
@@ -304,7 +306,7 @@ public class KurrentDbSubscriber
             catch
             {
                 IsLive = false;
-                _logger.LogInformation("Failed to create subscription retrying");
+                _logger.LogInformation("Failed to recreate subscription retrying");
             }
         }
     }

--- a/src/MessageDispatch.KurrentDB/KurrentDbSubscriber.cs
+++ b/src/MessageDispatch.KurrentDB/KurrentDbSubscriber.cs
@@ -95,15 +95,20 @@ public class KurrentDbSubscriber
     /// </summary>
     private void SetupCallbackTimer()
     {
-        //Create the timer and set it for a sixty second interval
-        _timer = new Timer();
-        _timer.Interval = 60000;
+        Version version = Environment.Version;
 
-        _timer.Elapsed += CallbackEvent;
+        if (version.Major < 8)
+        {
+            //Create the timer and set it for a sixty second interval
+            _timer = new Timer();
+            _timer.Interval = 60000;
 
-        _timer.AutoReset = true;
+            _timer.Elapsed += CallbackEvent;
 
-        _timer.Enabled = true;
+            _timer.AutoReset = true;
+
+            _timer.Enabled = true;
+        }
     }
 
     private void CallbackEvent(object source, ElapsedEventArgs e)

--- a/src/MessageDispatch.KurrentDB/KurrentDbSubscriber.cs
+++ b/src/MessageDispatch.KurrentDB/KurrentDbSubscriber.cs
@@ -267,7 +267,7 @@ public class KurrentDbSubscriber
             catch (Grpc.Core.RpcException ex)
             {
                 var innerWebException = ex.InnerException.InnerException;
-                if (innerWebException.Message.Contains("Error 12002"))
+                if (innerWebException != null && innerWebException.Message.Contains("Error 12002"))
                 {
                     _logger.LogInformation(ex, "Event Store subscription dropped {0}", SubscriptionDroppedReason.SubscriberError);
                     TryCreatingSubscription();

--- a/src/MessageDispatch.KurrentDB/KurrentDbSubscriber.cs
+++ b/src/MessageDispatch.KurrentDB/KurrentDbSubscriber.cs
@@ -102,7 +102,7 @@ public class KurrentDbSubscriber
 
     private void CallbackEvent(object source, ElapsedEventArgs e)
     {
-        _kurrentDbClient.ReadStreamAsync(Direction.Backwards, _streamName, StreamPosition.End);
+        _kurrentDbClient.ReadStreamAsync(Direction.Backwards, _streamName, StreamPosition.End, maxCount: 1);
     }
 
     /// <summary>

--- a/src/MessageDispatch.KurrentDB/KurrentDbSubscriber.cs
+++ b/src/MessageDispatch.KurrentDB/KurrentDbSubscriber.cs
@@ -212,7 +212,7 @@ public class KurrentDbSubscriber
         {
             try
             {
-                if(_subscription == null)
+                if (_subscription == null)
                 {
                     _subscription = CreateSubscription();
                     _logger.LogInformation("Subscribed to '{StreamName}'", _streamName);

--- a/src/MessageDispatch.KurrentDB/KurrentDbSubscriber.cs
+++ b/src/MessageDispatch.KurrentDB/KurrentDbSubscriber.cs
@@ -102,7 +102,10 @@ public class KurrentDbSubscriber
 
     private void CallbackEvent(object source, ElapsedEventArgs e)
     {
-        _kurrentDbClient.ReadStreamAsync(Direction.Backwards, _streamName, StreamPosition.End, maxCount: 1);
+        if (IsLive)
+        {
+            _kurrentDbClient.ReadStreamAsync(Direction.Backwards, _streamName, StreamPosition.End, maxCount: 1);
+        }
     }
 
     /// <summary>
@@ -238,6 +241,8 @@ public class KurrentDbSubscriber
     {
         _cts = new CancellationTokenSource();
 
+        SetupCallbackTimer();
+
         while (true)
         {
             try
@@ -275,8 +280,6 @@ public class KurrentDbSubscriber
                             break;
                     }
                 }
-
-                SetupCallbackTimer();
             }
             // User initiated drop, do not resubscribe
             catch (OperationCanceledException ex)

--- a/src/MessageDispatch.KurrentDB/KurrentDbSubscriber.cs
+++ b/src/MessageDispatch.KurrentDB/KurrentDbSubscriber.cs
@@ -245,6 +245,8 @@ public class KurrentDbSubscriber
                             IsLive = false;
                             break;
                     }
+
+                    winHttpExceptionHandled = false;
                 }
             }
             // User initiated drop, do not resubscribe

--- a/src/MessageDispatch.KurrentDB/KurrentDbSubscriber.cs
+++ b/src/MessageDispatch.KurrentDB/KurrentDbSubscriber.cs
@@ -270,14 +270,16 @@ public class KurrentDbSubscriber
 #if NETFRAMEWORK
             catch (Grpc.Core.RpcException ex)
             {
+                _startingPosition = _lastProcessedEventPosition;
+                _logger.LogInformation(ex, "Event Store subscription dropped {0}", SubscriptionDroppedReason.SubscriberError);
+
                 if (ex.InnerException != null && ex.InnerException.GetType() == typeof(IOException))
                 {
                     var innerWebException = ex.InnerException.InnerException;
                     if (innerWebException != null && innerWebException.Message.Contains("Error 12002"))
                     {
                         immediateRetry = true;
-                        _startingPosition = _lastProcessedEventPosition;
-                        _logger.LogInformation(ex, "Event Store subscription dropped {0}", SubscriptionDroppedReason.SubscriberError);
+                        _logger.LogInformation("Attempting to recreate subscription to '{StreamName}'", _streamName);
                     }
                 }
             }


### PR DESCRIPTION
https://qphl.atlassian.net/browse/PC-8589

When in .Net Framework v4.8.* the subscription is currently erroring. This is because the WinHttpHandler for Grpc.Net.Client that's being used by .Net Framework has a default timeout for idle requests of 90 - 120s. It also doesn't support any keep-alives or HTTP/2 pings, which causes it to be dropped because it gets classed as a stale connection.

## What's Changed

- Additional catch block for `RpcException` added only for NETFRAMEWORK implementations
- This allows for `IsLive` to remain true, with an immediate attempt to re-subscribe
- If the same errors occurs immediately after re-subscribing `IsLive` will be set to false as usual